### PR TITLE
fix: open-ended grading flow + dynamic MC options

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -16,7 +16,7 @@ interface DraftQuestion {
 const emptyQuestion = (): DraftQuestion => ({
   text: "",
   type: "multiple-choice",
-  options: ["", "", "", ""],
+  options: ["", ""],
   correctAnswerIndex: null,
   points: 1,
   timeLimit: null,
@@ -24,8 +24,8 @@ const emptyQuestion = (): DraftQuestion => ({
 
 function questionToDraft(q: Question): DraftQuestion {
   const options = q.type === "multiple-choice" && q.options?.length
-    ? [...q.options, ...Array(Math.max(0, 4 - q.options.length)).fill("")]
-    : ["", "", "", ""];
+    ? [...q.options, ...Array(Math.max(0, 2 - q.options.length)).fill("")]
+    : ["", ""];
   const correctAnswerIndex = q.correctAnswer && q.options
     ? q.options.indexOf(q.correctAnswer)
     : null;
@@ -98,6 +98,29 @@ function CreateQuizInner() {
           ? { ...q, options: q.options.map((o, j) => (j === optIdx ? value : o)) }
           : q
       )
+    );
+  }
+
+  function addOption(qIdx: number) {
+    setQuestions((prev) =>
+      prev.map((q, i) =>
+        i === qIdx ? { ...q, options: [...q.options, ""] } : q
+      )
+    );
+  }
+
+  function removeOption(qIdx: number, optIdx: number) {
+    setQuestions((prev) =>
+      prev.map((q, i) => {
+        if (i !== qIdx || q.options.length <= 2) return q;
+        const newOptions = q.options.filter((_, j) => j !== optIdx);
+        let newCorrect = q.correctAnswerIndex;
+        if (newCorrect !== null) {
+          if (newCorrect === optIdx) newCorrect = null;
+          else if (newCorrect > optIdx) newCorrect--;
+        }
+        return { ...q, options: newOptions, correctAnswerIndex: newCorrect };
+      })
     );
   }
 
@@ -337,8 +360,23 @@ function CreateQuizInner() {
                         placeholder={`Opcao ${optIdx + 1}`}
                         className="retro-input flex-1 text-sm py-1.5"
                       />
+                      {q.options.length > 2 && (
+                        <button
+                          onClick={() => removeOption(qIdx, optIdx)}
+                          className="text-red-400 hover:text-red-600 font-bold text-sm px-1"
+                          title="Remover opcao"
+                        >
+                          X
+                        </button>
+                      )}
                     </div>
                   ))}
+                  <button
+                    onClick={() => addOption(qIdx)}
+                    className="text-xs font-bold text-amber-700 hover:text-amber-900 underline mt-1"
+                  >
+                    + Adicionar opcao
+                  </button>
                   <p className="text-xs text-amber-600 mt-1">
                     Seleciona o radio da resposta correta
                   </p>

--- a/src/app/host/[code]/page.tsx
+++ b/src/app/host/[code]/page.tsx
@@ -505,15 +505,23 @@ function HostQuestion({
     }
   }, [remaining, questionOpen, code]);
 
-  // Auto-reveal when all players answered
+  // Auto-reveal when all players answered (MC only)
+  // For open-ended, just close answers so host can grade before revealing
   useEffect(() => {
     if (allAnswered && questionOpen) {
-      const timer = setTimeout(() => {
-        patchRoom(code, { phase: "reveal", questionOpen: false });
-      }, 2000);
-      return () => clearTimeout(timer);
+      if (questionType === "open-ended") {
+        const timer = setTimeout(() => {
+          patchRoom(code, { questionOpen: false });
+        }, 2000);
+        return () => clearTimeout(timer);
+      } else {
+        const timer = setTimeout(() => {
+          patchRoom(code, { phase: "reveal", questionOpen: false });
+        }, 2000);
+        return () => clearTimeout(timer);
+      }
     }
-  }, [allAnswered, questionOpen, code]);
+  }, [allAnswered, questionOpen, code, questionType]);
 
   return (
     <div className="space-y-6">
@@ -571,9 +579,11 @@ function HostQuestion({
           </div>
         )}
 
-        {questionType === "open-ended" && !questionOpen && answers.length > 0 && (
+        {questionType === "open-ended" && answers.length > 0 && (
           <div className="space-y-2 mb-6">
-            <h3 className="font-bold text-amber-800 text-lg">Respostas:</h3>
+            <h3 className="font-bold text-amber-800 text-lg">
+              Respostas:{questionOpen ? " (a receber...)" : ""}
+            </h3>
             {answers.map((a) => (
               <div
                 key={a.id}
@@ -589,28 +599,30 @@ function HostQuestion({
                   <span className="font-bold text-amber-900">{a.playerName}</span>
                   <span className="text-amber-700">— {a.answerText}</span>
                 </div>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => markAnswer(code, a.id, true)}
-                    className={`px-3 py-1 rounded-lg font-bold text-sm border-2 transition-colors ${
-                      a.isCorrect === true
-                        ? "bg-green-500 text-white border-green-600"
-                        : "bg-white text-green-600 border-green-300 hover:bg-green-50"
-                    }`}
-                  >
-                    Certo
-                  </button>
-                  <button
-                    onClick={() => markAnswer(code, a.id, false)}
-                    className={`px-3 py-1 rounded-lg font-bold text-sm border-2 transition-colors ${
-                      a.isCorrect === false
-                        ? "bg-red-500 text-white border-red-600"
-                        : "bg-white text-red-600 border-red-300 hover:bg-red-50"
-                    }`}
-                  >
-                    Errado
-                  </button>
-                </div>
+                {!questionOpen && (
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => markAnswer(code, a.id, true)}
+                      className={`px-3 py-1 rounded-lg font-bold text-sm border-2 transition-colors ${
+                        a.isCorrect === true
+                          ? "bg-green-500 text-white border-green-600"
+                          : "bg-white text-green-600 border-green-300 hover:bg-green-50"
+                      }`}
+                    >
+                      Certo
+                    </button>
+                    <button
+                      onClick={() => markAnswer(code, a.id, false)}
+                      className={`px-3 py-1 rounded-lg font-bold text-sm border-2 transition-colors ${
+                        a.isCorrect === false
+                          ? "bg-red-500 text-white border-red-600"
+                          : "bg-white text-red-600 border-red-300 hover:bg-red-50"
+                      }`}
+                    >
+                      Errado
+                    </button>
+                  </div>
+                )}
               </div>
             ))}
           </div>
@@ -626,7 +638,12 @@ function HostQuestion({
             Fechar Respostas
           </button>
         )}
-        {!questionOpen && (
+        {!questionOpen && questionType === "open-ended" && answers.some((a) => a.isCorrect === null) && (
+          <p className="text-amber-200 font-bold self-center">
+            Avalia todas as respostas antes de revelar
+          </p>
+        )}
+        {!questionOpen && (questionType !== "open-ended" || answers.every((a) => a.isCorrect !== null)) && (
           <button onClick={showReveal} className="retro-button">
             Revelar Resultado
           </button>
@@ -672,7 +689,7 @@ function HostReveal({
   }
 
   const correctPlayers = answers.filter((a) => a.isCorrect === true);
-  const wrongPlayers = answers.filter((a) => a.isCorrect === false);
+  const wrongPlayers = answers.filter((a) => a.isCorrect !== true);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Changes

### Open-ended question grading fix
- Fix open-ended questions skipping straight to reveal before host can grade answers
- When all players answer an open-ended question, auto-close answers (instead of auto-reveal)
- Show player answers as they arrive on the host screen
- Certo/Errado grading buttons appear after answers are closed
- 'Revelar Resultado' button is gated until all answers are graded
- Ungraded answers treated as wrong in reveal view (safety net)

### Dynamic multiple-choice options
- Quiz creator starts with 2 options instead of hardcoded 4
- Add/remove option buttons (minimum 2 required)
- Correct answer index adjusts when removing options
- Editing existing quizzes preserves original option count