### PR TITLE
feat: clone quiz + fix PUT error handling + strengthen tests

### DIFF
--- a/src/__tests__/api/quizzes-clone.test.ts
+++ b/src/__tests__/api/quizzes-clone.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mockPrisma, resetMocks } from "../setup";
+import { POST } from "@/app/api/quizzes/[id]/clone/route";
+
+function makeRequest(id: string) {
+  return {
+    request: new Request(`http://localhost/api/quizzes/${id}/clone`, { method: "POST" }),
+    params: Promise.resolve({ id }),
+  };
+}
+
+describe("POST /api/quizzes/[id]/clone", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it("clones a quiz preserving all question fields", async () => {
+    mockPrisma.quiz.findUnique.mockResolvedValue({
+      id: "q1",
+      title: "Original Quiz",
+      createdAt: "2025-01-01",
+      questions: [
+        { id: "qn1", text: "What?", type: "multiple-choice", options: ["A", "B", "C"], correctAnswer: "B", points: 2, timeLimit: 30, sortOrder: 0 },
+        { id: "qn2", text: "Why?", type: "open-ended", options: [], correctAnswer: null, points: 1, timeLimit: null, sortOrder: 1 },
+      ],
+    });
+    mockPrisma.quiz.create.mockResolvedValue({ id: "test-id-1234" });
+
+    const { request, params } = makeRequest("q1");
+    const res = await POST(request, { params });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.id).toBe("test-id-1234");
+
+    expect(mockPrisma.quiz.create).toHaveBeenCalledOnce();
+    const createCall = mockPrisma.quiz.create.mock.calls[0][0];
+
+    // Title gets "(copia)" suffix
+    expect(createCall.data.title).toBe("Original Quiz (copia)");
+
+    // All questions are cloned
+    const qs = createCall.data.questions.create;
+    expect(qs).toHaveLength(2);
+
+    // MC question: options, correctAnswer, points, timeLimit all preserved
+    expect(qs[0]).toMatchObject({
+      text: "What?",
+      type: "multiple-choice",
+      options: ["A", "B", "C"],
+      correctAnswer: "B",
+      points: 2,
+      timeLimit: 30,
+      sortOrder: 0,
+    });
+
+    // Open-ended question: null fields preserved
+    expect(qs[1]).toMatchObject({
+      text: "Why?",
+      type: "open-ended",
+      options: [],
+      correctAnswer: null,
+      points: 1,
+      timeLimit: null,
+      sortOrder: 1,
+    });
+  });
+
+  it("returns 404 for unknown quiz", async () => {
+    mockPrisma.quiz.findUnique.mockResolvedValue(null);
+    const { request, params } = makeRequest("nope");
+    const res = await POST(request, { params });
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.error).toMatch(/not found/i);
+  });
+
+  it("returns 500 when create fails", async () => {
+    mockPrisma.quiz.findUnique.mockResolvedValue({
+      id: "q1",
+      title: "Quiz",
+      questions: [{ id: "qn1", text: "Q?", type: "open-ended", options: [], correctAnswer: null, points: 1, timeLimit: null, sortOrder: 0 }],
+    });
+    mockPrisma.quiz.create.mockRejectedValue(new Error("DB error"));
+
+    const { request, params } = makeRequest("q1");
+    const res = await POST(request, { params });
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBeDefined();
+  });
+
+  it("generates new IDs for cloned quiz and questions", async () => {
+    mockPrisma.quiz.findUnique.mockResolvedValue({
+      id: "q1",
+      title: "Quiz",
+      questions: [{ id: "original-qn-id", text: "Q?", type: "open-ended", options: [], correctAnswer: null, points: 1, timeLimit: null, sortOrder: 0 }],
+    });
+    mockPrisma.quiz.create.mockResolvedValue({ id: "test-id-1234" });
+
+    const { request, params } = makeRequest("q1");
+    await POST(request, { params });
+
+    const createCall = mockPrisma.quiz.create.mock.calls[0][0];
+    // The cloned quiz and question IDs should be new (from nanoid mock: "test-id-1234"), not the originals
+    expect(createCall.data.id).toBe("test-id-1234");
+    expect(createCall.data.questions.create[0].id).toBe("test-id-1234");
+    expect(createCall.data.questions.create[0].id).not.toBe("original-qn-id");
+  });
+});

--- a/src/__tests__/api/quizzes-id.test.ts
+++ b/src/__tests__/api/quizzes-id.test.ts
@@ -59,15 +59,56 @@ describe("PUT /api/quizzes/[id]", () => {
     mockPrisma.quiz.findUnique.mockResolvedValue({ id: "q1" });
   });
 
-  it("updates title and questions", async () => {
+  it("updates title and questions with correct data", async () => {
     const { request, params } = makePutRequest("q1", {
-      title: "Updated",
-      questions: [{ text: "New Q?", type: "open-ended", points: 2 }],
+      title: "  Updated  ",
+      questions: [
+        { text: "New Q?", type: "open-ended", points: 2, timeLimit: 30 },
+        { text: "MC Q?", type: "multiple-choice", options: ["A", "B"], correctAnswer: "A", points: 3 },
+      ],
     });
     const res = await PUT(request, { params });
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.ok).toBe(true);
+
+    // Verify transaction was called with 3 operations: update title, delete old questions, create new
+    expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
+    const txOps = mockPrisma.$transaction.mock.calls[0][0];
+    expect(txOps).toHaveLength(3);
+
+    // Verify title was trimmed
+    expect(mockPrisma.quiz.update).toHaveBeenCalledWith({
+      where: { id: "q1" },
+      data: { title: "Updated" },
+    });
+
+    // Verify old questions deleted
+    expect(mockPrisma.question.deleteMany).toHaveBeenCalledWith({ where: { quizId: "q1" } });
+
+    // Verify new questions created with correct data
+    const createCall = mockPrisma.question.createMany.mock.calls[0][0];
+    expect(createCall.data).toHaveLength(2);
+    expect(createCall.data[0]).toMatchObject({
+      quizId: "q1",
+      text: "New Q?",
+      type: "open-ended",
+      options: [],
+      correctAnswer: null,
+      points: 2,
+      timeLimit: 30,
+      sortOrder: 0,
+    });
+    expect(createCall.data[1]).toMatchObject({
+      quizId: "q1",
+      text: "MC Q?",
+      type: "multiple-choice",
+      options: ["A", "B"],
+      correctAnswer: "A",
+      points: 3,
+      timeLimit: null,
+      sortOrder: 1,
+    });
   });
 
   it("returns 404 for unknown quiz", async () => {
@@ -81,6 +122,14 @@ describe("PUT /api/quizzes/[id]", () => {
     const { request, params } = makePutRequest("q1", { title: "New Title" });
     const res = await PUT(request, { params });
     expect(res.status).toBe(200);
+
+    // Only title update, no question operations
+    expect(mockPrisma.quiz.update).toHaveBeenCalledWith({
+      where: { id: "q1" },
+      data: { title: "New Title" },
+    });
+    expect(mockPrisma.question.deleteMany).not.toHaveBeenCalled();
+    expect(mockPrisma.question.createMany).not.toHaveBeenCalled();
   });
 
   it("updates only questions when no title provided", async () => {
@@ -89,20 +138,64 @@ describe("PUT /api/quizzes/[id]", () => {
     });
     const res = await PUT(request, { params });
     expect(res.status).toBe(200);
+
+    // No title update, only question delete + create
+    expect(mockPrisma.quiz.update).not.toHaveBeenCalled();
+    expect(mockPrisma.question.deleteMany).toHaveBeenCalledWith({ where: { quizId: "q1" } });
+    expect(mockPrisma.question.createMany).toHaveBeenCalledOnce();
   });
 
-  it("updates neither when body is empty", async () => {
+  it("skips transaction when body is empty", async () => {
     const { request, params } = makePutRequest("q1", {});
     const res = await PUT(request, { params });
     expect(res.status).toBe(200);
+
+    // No operations should be performed
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    expect(mockPrisma.quiz.update).not.toHaveBeenCalled();
+    expect(mockPrisma.question.deleteMany).not.toHaveBeenCalled();
+    expect(mockPrisma.question.createMany).not.toHaveBeenCalled();
   });
 
-  it("uses existing question id if provided", async () => {
+  it("uses existing question id if provided, generates one if not", async () => {
     const { request, params } = makePutRequest("q1", {
-      questions: [{ id: "existing-id", text: "Q?", type: "open-ended", points: 1 }],
+      questions: [
+        { id: "keep-this-id", text: "Q1?", type: "open-ended", points: 1 },
+        { text: "Q2?", type: "open-ended", points: 1 },
+      ],
     });
     const res = await PUT(request, { params });
     expect(res.status).toBe(200);
+
+    const createCall = mockPrisma.question.createMany.mock.calls[0][0];
+    expect(createCall.data[0].id).toBe("keep-this-id");
+    expect(createCall.data[1].id).toBe("test-id-1234"); // from nanoid mock
+  });
+
+  it("returns 500 with JSON error when transaction fails", async () => {
+    mockPrisma.$transaction.mockRejectedValue(new Error("DB connection lost"));
+    const { request, params } = makePutRequest("q1", {
+      title: "Updated",
+      questions: [{ text: "Q?", type: "open-ended", points: 1 }],
+    });
+    const res = await PUT(request, { params });
+    expect(res.status).toBe(500);
+    // The response must be valid JSON so the client can parse it
+    const data = await res.json();
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns 400 with JSON error when request body is not valid JSON", async () => {
+    const request = new Request("http://localhost/api/quizzes/q1", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "",  // empty body — triggers "Unexpected end of JSON input"
+    });
+    const params = Promise.resolve({ id: "q1" });
+    const res = await PUT(request, { params });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBeDefined();
   });
 });
 

--- a/src/__tests__/api/quizzes.test.ts
+++ b/src/__tests__/api/quizzes.test.ts
@@ -55,12 +55,13 @@ describe("POST /api/quizzes", () => {
     mockPrisma.quiz.create.mockResolvedValue({ id: "test-id-1234" });
   });
 
-  it("creates a quiz with valid data", async () => {
+  it("creates a quiz with valid data and correct structure", async () => {
     const res = await POST(
       makeRequest({
-        title: "My Quiz",
+        title: "  My Quiz  ",
         questions: [
-          { text: "Q1?", type: "multiple-choice", options: ["A", "B"], correctAnswer: "A" },
+          { text: "Q1?", type: "multiple-choice", options: ["A", "B"], correctAnswer: "A", points: 3 },
+          { text: "Q2?", type: "open-ended" },
         ],
       })
     );
@@ -68,6 +69,31 @@ describe("POST /api/quizzes", () => {
     const data = await res.json();
     expect(data.id).toBe("test-id-1234");
     expect(mockPrisma.quiz.create).toHaveBeenCalledOnce();
+
+    const createCall = mockPrisma.quiz.create.mock.calls[0][0];
+    // Title should be trimmed
+    expect(createCall.data.title).toBe("My Quiz");
+    // Questions should be nested creates
+    const qs = createCall.data.questions.create;
+    expect(qs).toHaveLength(2);
+    // MC question preserves options, correctAnswer, points
+    expect(qs[0]).toMatchObject({
+      text: "Q1?",
+      type: "multiple-choice",
+      options: ["A", "B"],
+      correctAnswer: "A",
+      points: 3,
+      sortOrder: 0,
+    });
+    // Open-ended question gets defaults
+    expect(qs[1]).toMatchObject({
+      text: "Q2?",
+      type: "open-ended",
+      options: [],
+      correctAnswer: null,
+      points: 1,
+      sortOrder: 1,
+    });
   });
 
   it("returns 400 if title is missing", async () => {
@@ -89,7 +115,7 @@ describe("POST /api/quizzes", () => {
     expect(res.status).toBe(400);
   });
 
-  it("handles questions with default points and no options/correctAnswer", async () => {
+  it("applies default points, empty options, and null correctAnswer for open-ended questions", async () => {
     const res = await POST(
       makeRequest({
         title: "Defaults Quiz",
@@ -101,5 +127,13 @@ describe("POST /api/quizzes", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.id).toBe("test-id-1234");
+
+    const createCall = mockPrisma.quiz.create.mock.calls[0][0];
+    const q = createCall.data.questions.create[0];
+    expect(q.points).toBe(1);
+    expect(q.options).toEqual([]);
+    expect(q.correctAnswer).toBeNull();
+    expect(q.timeLimit).toBeNull();
+    expect(q.sortOrder).toBe(0);
   });
 });

--- a/src/app/api/quizzes/[id]/clone/route.ts
+++ b/src/app/api/quizzes/[id]/clone/route.ts
@@ -1,0 +1,45 @@
+import { prisma } from "@/app/lib/prisma";
+import { nanoid } from "nanoid";
+import { NextResponse } from "next/server";
+
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  const quiz = await prisma.quiz.findUnique({
+    where: { id },
+    include: {
+      questions: { orderBy: { sortOrder: "asc" } },
+    },
+  });
+
+  if (!quiz) {
+    return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+  }
+
+  const newQuizId = nanoid(12);
+
+  try {
+    await prisma.quiz.create({
+      data: {
+        id: newQuizId,
+        title: `${quiz.title} (copia)`,
+        questions: {
+          create: quiz.questions.map((q, i) => ({
+            id: nanoid(12),
+            text: q.text,
+            type: q.type,
+            options: q.options as string[],
+            correctAnswer: q.correctAnswer,
+            points: q.points,
+            timeLimit: q.timeLimit,
+            sortOrder: i,
+          })),
+        },
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "Failed to clone quiz" }, { status: 500 });
+  }
+
+  return NextResponse.json({ id: newQuizId });
+}

--- a/src/app/api/quizzes/[id]/route.ts
+++ b/src/app/api/quizzes/[id]/route.ts
@@ -55,8 +55,18 @@ export async function DELETE(_request: Request, { params }: { params: Promise<{ 
 
 export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const body = await request.json();
-  const { title, questions } = body;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { title, questions } = body as {
+    title?: string;
+    questions?: { id?: string; text: string; type: string; options?: string[]; correctAnswer?: string; points?: number; timeLimit?: number | null }[];
+  };
 
   const quiz = await prisma.quiz.findUnique({ where: { id }, select: { id: true } });
   if (!quiz) {
@@ -73,7 +83,7 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   if (questions) {
     ops.push(prisma.question.deleteMany({ where: { quizId: id } }));
     ops.push(prisma.question.createMany({
-      data: questions.map((q: { id?: string; text: string; type: string; options?: string[]; correctAnswer?: string; points?: number; timeLimit?: number | null }, i: number) => ({
+      data: questions.map((q, i: number) => ({
         id: q.id || nanoid(12),
         quizId: id,
         text: q.text,
@@ -87,8 +97,12 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
     }));
   }
 
-  if (ops.length > 0) {
-    await prisma.$transaction(ops);
+  try {
+    if (ops.length > 0) {
+      await prisma.$transaction(ops);
+    }
+  } catch {
+    return NextResponse.json({ error: "Failed to update quiz" }, { status: 500 });
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/quizzes/page.tsx
+++ b/src/app/quizzes/page.tsx
@@ -17,6 +17,7 @@ export default function QuizzesPage() {
   const [deleting, setDeleting] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [creating, setCreating] = useState<string | null>(null);
+  const [cloning, setCloning] = useState<string | null>(null);
 
   const fetchQuizzes = useCallback(async () => {
     try {
@@ -60,6 +61,18 @@ export default function QuizzesPage() {
     } finally {
       setDeleting(null);
       setConfirmDelete(null);
+    }
+  }
+
+  async function handleClone(quizId: string) {
+    setCloning(quizId);
+    try {
+      const res = await fetch(`/api/quizzes/${quizId}/clone`, { method: "POST" });
+      if (res.ok) {
+        await fetchQuizzes();
+      }
+    } finally {
+      setCloning(null);
     }
   }
 
@@ -143,6 +156,13 @@ export default function QuizzesPage() {
                     className="retro-button retro-button-secondary text-sm !py-1.5 !px-3"
                   >
                     Editar
+                  </button>
+                  <button
+                    onClick={() => handleClone(quiz.id)}
+                    disabled={cloning === quiz.id}
+                    className="retro-button retro-button-secondary text-sm !py-1.5 !px-3"
+                  >
+                    {cloning === quiz.id ? "A copiar..." : "Duplicar"}
                   </button>
                   {confirmDelete === quiz.id ? (
                     <div className="flex gap-1">


### PR DESCRIPTION
## Changes

### Clone quiz feature
- New `POST /api/quizzes/[id]/clone` endpoint that duplicates a quiz with all its questions, appending `(copia)` to the title
- "Duplicar" button added to the quizzes list page (`/quizzes`)
- 4 tests covering: successful clone with field preservation, 404, 500, and new ID generation

### Fix PUT error handling
- `PUT /api/quizzes/[id]` now wraps `request.json()` in try/catch (returns 400 on malformed body)
- Wraps `prisma.$transaction()` in try/catch (returns 500 on DB failure)
- This fixes the "Unexpected end of JSON input" error users saw when editing a quiz

### Test quality improvements
- Strengthened existing tests across `quizzes.test.ts` and `quizzes-id.test.ts` to verify actual Prisma call arguments (title trimming, question field mapping, sortOrder, defaults) instead of only checking HTTP status codes
- Tests now verify that operations that should NOT happen (e.g. question delete when only title changes) are indeed not called

## Test results
All 102 tests pass.